### PR TITLE
Automate blog rollup

### DIFF
--- a/components/rollup.js
+++ b/components/rollup.js
@@ -1,60 +1,38 @@
-const posts = [
-  {
-    title: 'Run AI models with ollama in CI with GitHub Actions.',
-    href: '/blog/ollama-in-github-actions',
-    description: 'With the new GPU support for actuated, we\'ve been able to run models like llama2 from ollama in CI on consumer and datacenter grade Nvidia cards.',
-    date: 'April 25, 2024',
-  },
-    {
-      title: 'On Running Millions of Arm CI Minutes for the CNCF',
-      href: '/blog/millions-of-cncf-minutes',
-      description: 'We\'ve now run over 1.5 million minutes of CI time for various CNCF projects on Ampere hardware. Here\'s what we\'ve learned.',
-      date: 'May 30, 2024',
-    },
-    {
-      title: 'How Calyptia fixed its Arm builds whilst saving money',
-      href: '/blog/calyptia-case-study-arm',
-      description:
-        'Learn how Calyptia fixed its failing Arm builds for open-source Fluent Bit and accelerated our commercial development by adopting Actuated and bare-metal runners.',
-      date: 'August 11, 2023',
-    }
-  ]
-  
-  function classNames(...classes) {
-    return classes.filter(Boolean).join(' ')
-  }
-  
-  export default function BlogRollup() {
-    return (
-      <div className="bg-white px-6 lg:px-8 lg:pt-8 lg:pb-10">
-        <div className="mx-auto mt-2 max-w-xl px-4 lg:max-w-7xl lg:px-6">
-            <p className='mt-2 mx-10 text-2xl font-semibold leading-8 tracking-tight text-gray-900'>
-                Improve your builds with our tips & tricks
-            </p>
-            <p className='mt-4 mx-10 text-base leading-7 text-gray-600 text-justify'>
-              Learn how to improve the speed and efficiency your GitHub Actions with our examples and best practices.
-            </p>
-          
-          <div className="mx-10 grid gap-16 pt-12 lg:grid-cols-3 lg:gap-x-5 lg:gap-y-12">
-            {posts.map((post) => (
-              <div key={post.title}>
-                <a href={post.href} className="mt-4 block">
-                  <p className="text-xl font-semibold text-gray-900">{post.title}</p>
-                  <p className="mt-3 text-base text-gray-500">{post.description}</p>
-                </a>
-                <div className="mt-6 flex items-center">
-                  <div className="">
-                    <div className="flex space-x-1 text-sm text-gray-500">
-                      <span>{post.date}</span>
-                      <span aria-hidden="true">&middot;</span>
-                    </div>
+export default function BlogRollup({posts}) {
+  return (
+    <div className="bg-white px-6 lg:px-8 lg:pt-4 lg:pb-6">
+      <div className="mx-auto mt-2 max-w-xl px-4 lg:max-w-7xl lg:px-6">
+        <p className="mt-2 mx-10 text-2xl font-semibold leading-8 tracking-tight text-gray-900">
+          Improve your builds with our tips & tricks
+        </p>
+        <p className="mt-4 mx-10 text-base leading-7 text-gray-600 text-justify">
+          Learn how to improve the speed and efficiency your GitHub Actions with
+          our examples and best practices.
+        </p>
+
+        <div className="mx-10 grid gap-x-6 gap-y-2 pt-8 lg:grid-cols-3">
+          {posts.map((post) => (
+            <div key={post.title}>
+              <a href={`/blog/${post.slug}`} className="mt-4 block">
+                <p className="text-xl font-semibold text-gray-900">
+                  {post.title}
+                </p>
+                <p className="mt-3 text-base text-gray-500">
+                  {post.description}
+                </p>
+              </a>
+              <div className="mt-6 flex items-center">
+                <div className="">
+                  <div className="flex space-x-1 text-sm text-gray-500">
+                    <span>{post.date}</span>
                   </div>
                 </div>
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
         </div>
       </div>
-    )
-  }
-  
+    </div>
+  );
+}
+

--- a/components/testimonial.js
+++ b/components/testimonial.js
@@ -66,7 +66,7 @@ const testimonials = [
 
 export default function Testimonial() {
       return (
-        <div className="bg-white py-10 sm:py-15">
+        <div className="bg-white py-4 sm:py-6">
           <div className="mx-auto max-w-7xl px-6 lg:px-8">
             <div className="mx-auto max-w-xl text-center">
               <p className="mt-2 text-2xl  font-bold tracking-tight text-gray-900 sm:text-4xl">

--- a/lib/posts.js
+++ b/lib/posts.js
@@ -45,6 +45,27 @@ export function getSortedPostsMetadata() {
   });
 }
 
+export function getRollupPosts(count) {
+  const posts = getPosts()
+    .map((post) => {
+      const metadata = getPostMetadata(post);
+
+      return { slug: post.slug, ...metadata };
+    })
+    .filter((post) => post.rollup == true)
+    .sort((a, b) => {
+      // Sort posts by datec
+      if (a.date < b.date) {
+        return 1;
+      } else {
+        return -1;
+      }
+    })
+    .slice(0, count);
+
+  return posts
+}
+
 export function getPostMetadata(post) {
   // Read markdown file as string
   const fullPath = path.join(postsDirectory, post.fileName);

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,9 +8,10 @@ import TestimonialPrimary from '../components/testimonial-primary'
 import GitHubQuote from '../components/GitHubQuote'
 import BlogRollup from '../components/rollup'
 // import Subscribe from '../components/subscribe'
+import { getRollupPosts } from '../lib/posts';
 
 
-export default function Home() {
+export default function Home({ rollupPosts }) {
   return (
     <>
       <div>
@@ -109,7 +110,7 @@ export default function Home() {
 
       <Solutions></Solutions>
 
-      <BlogRollup></BlogRollup>
+      <BlogRollup posts={rollupPosts}></BlogRollup>
 
       <Testimonial></Testimonial>
 
@@ -122,5 +123,12 @@ export default function Home() {
   )
 }
 
+export async function getStaticProps() {  
+  return {
+    props: {
+      rollupPosts: getRollupPosts(6)
+    },
+  };
+}
 
 

--- a/posts/2023-08-11-calyptia-case-study-arm.md
+++ b/posts/2023-08-11-calyptia-case-study-arm.md
@@ -6,6 +6,7 @@ tags:
 - packer
 - qemu
 - kvm
+rollup: true
 author_img: patrick-stephens
 image: /images/2023-08-calyptia-casestudy/background.png
 date: "2023-08-11"

--- a/posts/2024-03-25-ollama-in-github-actions.md
+++ b/posts/2024-03-25-ollama-in-github-actions.md
@@ -10,6 +10,7 @@ tags:
 - openai
 - llama
 - machinelearning
+rollup: true
 author_img: alex
 image: /images/2024-04-ollama-in-ci/background.png
 date: "2024-04-25"

--- a/posts/2024-05-30-millions-of-cncf-minutes.md
+++ b/posts/2024-05-30-millions-of-cncf-minutes.md
@@ -5,6 +5,7 @@ tags:
 - cncf
 - enablement
 - arm
+rollup: true
 author_img: alex
 image: /images/2024-05-cncf-millions/background.png
 date: "2024-05-30"


### PR DESCRIPTION
## Description

Automatically generate the blog rollup.

A post can be included in the rollup by setting `rollup: true` in the yaml front matter. The 6 most recent rollup post are displayed on the home page.